### PR TITLE
Situational connector visibility

### DIFF
--- a/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingConnector.java
+++ b/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingConnector.java
@@ -78,7 +78,8 @@ public final class IncomingConnector extends InteractiveElement {
     }
 
     private boolean isVisible(State state) {
-	//Set to true to avoid lane-connectivity issues, for now
+    	//Keep invisible so we can use IncomingLaneConnector,
+    	//but still allow to exist so Road.java doesn't break
         return false;
     }
 

--- a/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
+++ b/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
@@ -7,10 +7,13 @@ import java.awt.Graphics2D;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 
+import org.openstreetmap.josm.tools.Logging;
 
 import com.kaart.laneconnectivity.gui.InteractiveElement;
 import com.kaart.laneconnectivity.gui.LaneGui;
 import com.kaart.laneconnectivity.gui.State;
+import com.kaart.laneconnectivity.model.Junction;
+import com.kaart.laneconnectivity.model.Road;
 
 public final class IncomingLaneConnector extends InteractiveElement {
     private final Point2D center = new Point2D.Double();
@@ -54,11 +57,30 @@ public final class IncomingLaneConnector extends InteractiveElement {
     }
 
     private boolean isVisible(State state) {
-	if (laneGui.getRoad().getModel().isPrimary()) {
+    	if (laneGui.getRoad().getModel().isPrimary()) {
             return false;
         }
-	//Make always visible to avoid lane connectivity issues, for now
-	return true;
+    	
+    	
+    	if (state instanceof State.Connecting) {
+	    	final State.Connecting s = (State.Connecting) state;
+	    	final Junction junc1 =  s.getLane().getOutgoingJunction();
+	    	final Junction junc2 = laneGui.getModel().getRoad().getToEnd().getJunction();
+	    	Logging.info("1: " + junc1.toString());
+	    	Logging.info("2: " + junc2.toString());
+	    	for (ViaConnector via : s.getViaConnectors()) {
+	    		if (via.getRoadEnd().getJunction().equals(junc2)) {
+	    			return true;
+	    		}
+	    	}
+	    	if (junc1.equals(junc2)) {
+	    		return true;
+	    	}
+	    	return false;
+    	}
+
+		//Make always visible to avoid lane connectivity issues, for now
+    	return false;
     }
 
     @Override

--- a/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
+++ b/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
@@ -66,9 +66,9 @@ public final class IncomingLaneConnector extends InteractiveElement {
 	    	final State.Connecting s = (State.Connecting) state;
 	    	final Junction junc1 =  s.getJunction();
 	    	final Junction junc2 = laneGui.getModel().getRoad().getToEnd().getJunction();
-	    	Logging.info("1: " + junc1.toString());
-	    	Logging.info("2: " + junc2.toString());
-	    	if (junc1.equals(junc2)) {
+	    	final Road road1 = s.getLane().getRoad();
+	    	final Road road2 = laneGui.getModel().getRoad();
+	    	if (junc1.equals(junc2) && !road1.equals(road2)) {
 	    		return true;
 	    	}
 	    	return false;

--- a/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
+++ b/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
@@ -7,8 +7,6 @@ import java.awt.Graphics2D;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Point2D;
 
-import org.openstreetmap.josm.tools.Logging;
-
 import com.kaart.laneconnectivity.gui.InteractiveElement;
 import com.kaart.laneconnectivity.gui.LaneGui;
 import com.kaart.laneconnectivity.gui.State;
@@ -73,8 +71,7 @@ public final class IncomingLaneConnector extends InteractiveElement {
 	    	}
 	    	return false;
     	}
-
-		//Make always visible to avoid lane connectivity issues, for now
+    	
     	return false;
     }
 

--- a/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
+++ b/src/main/java/com/kaart/laneconnectivity/gui/connector/IncomingLaneConnector.java
@@ -64,15 +64,10 @@ public final class IncomingLaneConnector extends InteractiveElement {
     	
     	if (state instanceof State.Connecting) {
 	    	final State.Connecting s = (State.Connecting) state;
-	    	final Junction junc1 =  s.getLane().getOutgoingJunction();
+	    	final Junction junc1 =  s.getJunction();
 	    	final Junction junc2 = laneGui.getModel().getRoad().getToEnd().getJunction();
 	    	Logging.info("1: " + junc1.toString());
 	    	Logging.info("2: " + junc2.toString());
-	    	for (ViaConnector via : s.getViaConnectors()) {
-	    		if (via.getRoadEnd().getJunction().equals(junc2)) {
-	    			return true;
-	    		}
-	    	}
 	    	if (junc1.equals(junc2)) {
 	    		return true;
 	    	}

--- a/src/main/java/com/kaart/laneconnectivity/gui/connector/OutgoingConnector.java
+++ b/src/main/java/com/kaart/laneconnectivity/gui/connector/OutgoingConnector.java
@@ -90,7 +90,6 @@ public final class OutgoingConnector extends InteractiveElement {
     }
 
     private boolean isVisible(State state) {
-	//Make always visible to avoid lane-connectivity issues, for now
         return true;
     }
 

--- a/src/main/java/com/kaart/laneconnectivity/gui/connector/ViaConnector.java
+++ b/src/main/java/com/kaart/laneconnectivity/gui/connector/ViaConnector.java
@@ -54,14 +54,14 @@ public final class ViaConnector extends InteractiveElement {
         }
 
         final State.Connecting s = (State.Connecting) state;
-
-        if (s.getJunction().equals(end.getJunction()) || equals(s.getBacktrackViaConnector())) {
-            return true;
+        
+        if (s.getJunction().equals(end.getJunction()) && roadGui.getModel().getToEnd().equals(end)) {
+        	return true;
         } else if (!s.getViaConnectors().isEmpty()
                 && s.getViaConnectors().get(s.getViaConnectors().size() - 1).getRoadModel().equals(getRoadModel())) {
             return true;
         }
-
+        
         return false;
     }
 


### PR DESCRIPTION
Respective incoming / outgoing connectors will only show appear if it makes sense for them to be connected to. For example, you can't connect a 'from' and 'to' way without hitting appropriate 'via' members between the two.